### PR TITLE
handle 419 body too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     unleash = {
       source  = "LINEMANWongnai/unleash"
-      version = "1.1.4"
+      version = "1.2.0"
     }
   }
 }

--- a/docs/resources/feature.md
+++ b/docs/resources/feature.md
@@ -41,7 +41,7 @@ Required:
 
 Optional:
 
-- `variants` (Attributes Set) Variants of this feature (see [below for nested schema](#nestedatt--environments--variants))
+- `variants` (Attributes List) Variants of this feature (see [below for nested schema](#nestedatt--environments--variants))
 
 <a id="nestedatt--environments--strategies"></a>
 ### Nested Schema for `environments.strategies`
@@ -58,7 +58,7 @@ Optional:
 - `segments` (Set of Number) Segment IDs of this strategy
 - `sort_order` (Number) Sort order
 - `title` (String) Title of this strategy
-- `variants` (Attributes Set) Variants of this strategy (see [below for nested schema](#nestedatt--environments--strategies--variants))
+- `variants` (Attributes List) Variants of this strategy (see [below for nested schema](#nestedatt--environments--strategies--variants))
 
 Read-Only:
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -173,7 +173,7 @@ func toStrategyAttributes(strategy unleash.FeatureStrategySchema) (map[string]ct
 
 func toVariants(variants []unleash.VariantSchema) (cty.Value, error) {
 	if len(variants) == 0 {
-		return cty.NullVal(cty.Set(variantType)), nil
+		return cty.NullVal(cty.List(variantType)), nil
 	}
 	variantValues := make([]cty.Value, 0, len(variants))
 	for _, variant := range variants {
@@ -197,12 +197,12 @@ func toVariants(variants []unleash.VariantSchema) (cty.Value, error) {
 		}
 		overrides, err := toVariantOverrides(variant.Overrides)
 		if err != nil {
-			return cty.NullVal(cty.Set(variantType)), err
+			return cty.NullVal(cty.List(variantType)), err
 		}
 		attributes["overrides"] = overrides
 		variantValues = append(variantValues, cty.ObjectVal(attributes))
 	}
-	return cty.SetVal(variantValues), nil
+	return cty.ListVal(variantValues), nil
 }
 
 func toVariantOverrides(overrides *[]unleash.OverrideSchema) (cty.Value, error) {
@@ -306,7 +306,7 @@ func toSegments(segments *[]float32) cty.Value {
 
 func toStrategyVariants(variants *[]unleash.StrategyVariantSchema) cty.Value {
 	if variants == nil || len(*variants) == 0 {
-		return cty.NullVal(cty.Set(strategyVariantType))
+		return cty.NullVal(cty.List(strategyVariantType))
 	}
 	variantValues := make([]cty.Value, 0, len(*variants))
 	for _, variant := range *variants {
@@ -327,5 +327,5 @@ func toStrategyVariants(variants *[]unleash.StrategyVariantSchema) cty.Value {
 		}
 		variantValues = append(variantValues, cty.ObjectVal(attributes))
 	}
-	return cty.SetVal(variantValues)
+	return cty.ListVal(variantValues)
 }

--- a/internal/generator/type.go
+++ b/internal/generator/type.go
@@ -20,7 +20,7 @@ func createEnvironmentType() cty.Type {
 	return cty.Object(map[string]cty.Type{
 		"enabled":    cty.Bool,
 		"strategies": cty.Set(createStrategyType()),
-		"variants":   cty.Set(createVariantType()),
+		"variants":   cty.List(createVariantType()),
 	})
 }
 
@@ -52,7 +52,7 @@ func createStrategyType() cty.Type {
 		"constraints": cty.Set(createConstraintType()),
 		"parameters":  cty.Map(cty.String),
 		"segments":    cty.List(cty.Number),
-		"variants":    cty.Set(createStrategyVariantType()),
+		"variants":    cty.List(createStrategyVariantType()),
 	})
 }
 

--- a/internal/inmem/server_unimplemented.go
+++ b/internal/inmem/server_unimplemented.go
@@ -431,11 +431,6 @@ func (t TestServer) PatchFeatureStrategy(ctx context.Context, request unleash.Pa
 	panic("implement me")
 }
 
-func (t TestServer) PatchEnvironmentsFeatureVariants(ctx context.Context, request unleash.PatchEnvironmentsFeatureVariantsRequestObject) (unleash.PatchEnvironmentsFeatureVariantsResponseObject, error) {
-	//TODO implement me
-	panic("implement me")
-}
-
 func (t TestServer) OverwriteEnvironmentFeatureVariants(ctx context.Context, request unleash.OverwriteEnvironmentFeatureVariantsRequestObject) (unleash.OverwriteEnvironmentFeatureVariantsResponseObject, error) {
 	//TODO implement me
 	panic("implement me")

--- a/internal/provider/feature_internal_test.go
+++ b/internal/provider/feature_internal_test.go
@@ -1,0 +1,270 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestGetVariantDiffMode(t *testing.T) {
+	tests := []struct {
+		name             string
+		variants         []VariantModel
+		existingVariants []VariantModel
+		result           variantsDiff
+	}{
+		{
+			name: "equal",
+			variants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+			},
+			result: variantsDiff{
+				Mode: variantDiffModeEqual,
+			},
+		},
+		{
+			name: "switch sequence",
+			variants: []VariantModel{
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToReplace: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 3},
+				},
+				Mode: variantDiffModeReplaceOnly,
+			},
+		},
+		{
+			name: "change content only",
+			variants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload 2")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToReplace: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")}, Index: 1},
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload 2")}, Index: 2},
+				},
+				Mode: variantDiffModeReplaceOnly,
+			},
+		},
+		{
+			name: "change content",
+			variants: []VariantModel{
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToReplace: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")}, Index: 1},
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 3},
+				},
+				Mode: variantDiffModeReplaceOnly,
+			},
+		},
+		{
+			name: "new variants",
+			variants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+			},
+			existingVariants: []VariantModel{},
+			result: variantsDiff{
+				ToAdd: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")}, Index: 1},
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+				},
+				Mode: variantDiffModeAddOnly,
+			},
+		},
+		{
+			name: "add variants only",
+			variants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+			},
+			result: variantsDiff{
+				ToAdd: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+				},
+				Mode: variantDiffModeAddOnly,
+			},
+		},
+		{
+			name: "add and change",
+			variants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload 2")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToAdd: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+				},
+				ToReplace: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload 2")}, Index: 1},
+				},
+				Mode: variantDiffModeMixed,
+			},
+		},
+		{
+			name: "remove",
+			variants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToRemove: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")}, Index: 1},
+				},
+				Mode: variantDiffModeRemoveOnly,
+			},
+		},
+		{
+			name: "remove and change",
+			variants: []VariantModel{
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload 2")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToRemove: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 0},
+				},
+				ToReplace: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")}, Index: 1},
+					{Variant: VariantModel{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload 2")}, Index: 3},
+				},
+				Mode: variantDiffModeMixed,
+			},
+		},
+		{
+			name: "add and remove",
+			variants: []VariantModel{
+				{Name: types.StringValue("v5"), Payload: types.StringValue("v5 payload")},
+				{Name: types.StringValue("v6"), Payload: types.StringValue("v6 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+				{Name: types.StringValue("v7"), Payload: types.StringValue("v7 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToAdd: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v5"), Payload: types.StringValue("v5 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v6"), Payload: types.StringValue("v6 payload")}, Index: 1},
+					{Variant: VariantModel{Name: types.StringValue("v7"), Payload: types.StringValue("v7 payload")}, Index: 4},
+				},
+				ToRemove: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 0},
+				},
+				Mode: variantDiffModeMixed,
+			},
+		},
+		{
+			name: "mixed",
+			variants: []VariantModel{
+				{Name: types.StringValue("v5"), Payload: types.StringValue("v5 payload")},
+				{Name: types.StringValue("v6"), Payload: types.StringValue("v6 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+				{Name: types.StringValue("v7"), Payload: types.StringValue("v7 payload")},
+			},
+			existingVariants: []VariantModel{
+				{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")},
+				{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload")},
+				{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")},
+				{Name: types.StringValue("v4"), Payload: types.StringValue("v4 payload")},
+			},
+			result: variantsDiff{
+				ToAdd: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v5"), Payload: types.StringValue("v5 payload")}, Index: 0},
+					{Variant: VariantModel{Name: types.StringValue("v6"), Payload: types.StringValue("v6 payload")}, Index: 1},
+					{Variant: VariantModel{Name: types.StringValue("v7"), Payload: types.StringValue("v7 payload")}, Index: 4},
+				},
+				ToRemove: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v3"), Payload: types.StringValue("v3 payload")}, Index: 2},
+					{Variant: VariantModel{Name: types.StringValue("v1"), Payload: types.StringValue("v1 payload")}, Index: 0},
+				},
+				ToReplace: []variantModelWithIndex{
+					{Variant: VariantModel{Name: types.StringValue("v2"), Payload: types.StringValue("v2 payload 2")}, Index: 1},
+				},
+				Mode: variantDiffModeMixed,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getVariantDiffMode(tt.variants, tt.existingVariants); !reflect.DeepEqual(got, tt.result) {
+				t.Errorf("getVariantDiffMode() = %v, want %v", got, tt.result)
+			}
+		})
+	}
+}

--- a/internal/provider/feature_resource_test.go
+++ b/internal/provider/feature_resource_test.go
@@ -1,7 +1,9 @@
 package provider_test
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -39,7 +41,7 @@ resource "unleash_feature" "minimal" {
 			]
 		}
 		development = {
-			enabled = false
+			enabled = true
 			strategies = [
 				{
 					name = "flexibleRollout"
@@ -66,7 +68,7 @@ resource "unleash_feature" "minimal" {
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.production.strategies.0.parameters.rollout", "100"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.production.strategies.0.parameters.stickiness", "default"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.production.strategies.0.parameters.groupId", "test-feature.minimal"),
-					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.enabled", "false"),
+					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.enabled", "true"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.strategies.0.name", "flexibleRollout"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.strategies.0.disabled", "false"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.strategies.0.parameters.rollout", "100"),
@@ -115,7 +117,7 @@ resource "unleash_feature" "minimal" {
 			]
 		}
 		development = {
-			enabled = true
+			enabled = false
 			strategies = [
 				{
 					name = "flexibleRollout"
@@ -143,7 +145,7 @@ resource "unleash_feature" "minimal" {
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.production.strategies.0.parameters.rollout", "100"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.production.strategies.0.parameters.stickiness", "session"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.production.strategies.0.parameters.groupId", "test-feature.minimal"),
-					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.enabled", "true"),
+					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.enabled", "false"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.strategies.0.name", "flexibleRollout"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.strategies.0.disabled", "false"),
 					resource.TestCheckResourceAttr("unleash_feature.minimal", "environments.development.strategies.0.parameters.rollout", "50"),
@@ -563,6 +565,240 @@ resource "unleash_feature" "full" {
 						"parameters.groupId":    "test-feature.full",
 					}),
 				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccFeatureResourceLarge(t *testing.T) {
+	providerConf := getProviderConf(inmem.CreateTestServer().Start(t))
+
+	largeConfigFmt := `
+resource "unleash_feature" "large" {
+	project = "default"
+	name = "test-feature.large"
+	type = "release"
+	environments = {
+		production = {
+			enabled = false
+			strategies = [
+				{
+					name = "flexibleRollout"
+					disabled = false
+					parameters = {
+						"rollout" = "100"
+						"stickiness" = "session"
+						"groupId" = "test-feature.full"
+					}
+				},
+			]
+			variants = [
+				%s
+				{
+					name = "variant1"
+					payload = "payload1"
+					payload_type = "string"
+					weight = 5
+					weight_type = "fix"
+					stickiness = "default"
+					overrides = [
+						{
+							context_name = "userId"
+							values_json = jsonencode(%s)
+						},
+						{
+							context_name = "device"
+							values_json = jsonencode(["iphone"])
+						},
+					]
+				},
+				{
+					name = "variant2"
+					payload = "payload2"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},
+				%s
+			]
+		}
+		development = {
+			enabled = false
+			strategies = [
+				{
+					name = "flexibleRollout"
+					disabled = false
+					parameters = {
+						"rollout" = "100"
+						"stickiness" = "default"
+						"groupId" = "test-feature.minimal"
+					}
+				},
+			]
+		}
+	}
+}
+`
+
+	notEmptyRegex := regexp.MustCompile(`.+`)
+
+	largeCheckFn := func(variantsLen int) resource.TestCheckFunc {
+		return resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("unleash_feature.large", "id", "default.test-feature.large"),
+			resource.TestCheckResourceAttr("unleash_feature.large", "project", "default"),
+			resource.TestCheckResourceAttr("unleash_feature.large", "name", "test-feature.large"),
+			resource.TestCheckResourceAttr("unleash_feature.large", "type", "release"),
+			resource.TestCheckResourceAttr("unleash_feature.large", "environments.production.enabled", "false"),
+			resource.TestCheckResourceAttr("unleash_feature.large", "environments.production.strategies.#", "1"),
+			resource.TestCheckTypeSetElemNestedAttrs("unleash_feature.large", "environments.production.strategies.*", map[string]string{
+				"name":                  "flexibleRollout",
+				"disabled":              "false",
+				"parameters.rollout":    "100",
+				"parameters.stickiness": "session",
+				"parameters.groupId":    "test-feature.full",
+			}),
+			resource.TestMatchResourceAttr("unleash_feature.large", "environments.production.strategies.0.id", notEmptyRegex),
+			resource.TestCheckResourceAttr("unleash_feature.large", "environments.production.variants.#", strconv.Itoa(variantsLen)),
+		)
+	}
+
+	beginArray := `["-"`
+	largeOverrideValues := ""
+	for i := 0; i < 101; i++ {
+		largeOverrideValues += fmt.Sprintf(`,"%d"`, i)
+	}
+	endArray := "]"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt, "", beginArray+largeOverrideValues+endArray, ""),
+				Check:  largeCheckFn(2),
+			},
+			// ImportState testing
+			{
+				ResourceName:  "unleash_feature.large",
+				ImportStateId: "default.test-feature.large",
+				Config: providerConf + `
+resource "unleash_feature" "large" {
+  project = "default"
+  name = "test-feature.large"
+}`,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// This is not normally necessary, but is here because this
+				// example code does not have an actual upstream service.
+				// Once the Read method is able to refresh information from
+				// the upstream service, this can be removed.
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt,
+					`{
+					name = "variant3"
+					payload = "payload3"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`,
+					beginArray+largeOverrideValues+endArray,
+					`{
+					name = "variant4"
+					payload = "payload4"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`),
+				Check: largeCheckFn(4),
+			},
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt,
+					`{
+					name = "variant3"
+					payload = "payload3 mod"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`,
+					beginArray+largeOverrideValues+endArray,
+					`{
+					name = "variant4"
+					payload = "payload4 mod"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`),
+				Check: largeCheckFn(4),
+			},
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt, "", beginArray+largeOverrideValues+endArray, `{
+					name = "variant3"
+					payload = "payload3 mod 2"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},
+				{
+					name = "variant4"
+					payload = "payload4 mod 2"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`),
+				Check: largeCheckFn(4),
+			},
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt, `{
+					name = "variant3"
+					payload = "payload3 mod 3"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`,
+					beginArray+largeOverrideValues+endArray, `
+				{
+					name = "variant4"
+					payload = "payload4 mod 3"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},
+				{	
+					name = "variant5"
+					payload = "payload5"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`),
+				Check: largeCheckFn(5),
+			},
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt,
+					"",
+					beginArray+largeOverrideValues+endArray, `
+				{
+					name = "variant4"
+					payload = "payload4 mod 4"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},
+				{	
+					name = "variant5"
+					payload = "payload5 mod 2"
+					payload_type = "string"
+					weight_type = "variable"
+					stickiness = "default"
+				},`),
+				Check: largeCheckFn(4),
+			},
+			{
+				Config: providerConf + fmt.Sprintf(largeConfigFmt, "", beginArray+largeOverrideValues+endArray, ""),
+				Check:  largeCheckFn(2),
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
Unleash server uses express for reading json body with default config which limit the size of body. It responses with 419 status code (body too large) if variants body is too large. 

This change adds code to handle the 419 status code, it tries to patch variant one by one instead. However, if it detects if a change combines add, remove or replace it needs to put all variants without `payload` and `overrides` first then patch.